### PR TITLE
Hotfix: Corregir validación de token

### DIFF
--- a/Infraestructura/Sesiones/ProveedorAutenticacion.cs
+++ b/Infraestructura/Sesiones/ProveedorAutenticacion.cs
@@ -38,11 +38,16 @@ namespace Infraestructura.Sesiones
                 {
                     http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
 
-                    var user = await http.GetFromJsonAsync<Usuario>("/api/sesion");
-                    var service = new ServicioSesion();
+                    var response = await http.GetAsync("/api/sesion");
 
-                    var identity = service.GenerarIdentidad(user);
-                    status = new AuthenticationState(identity);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var user = await response.Content.ReadFromJsonAsync<Usuario>();
+                        var service = new ServicioSesion();
+
+                        var identity = service.GenerarIdentidad(user);
+                        status = new AuthenticationState(identity);
+                    }
                 }
             }
 

--- a/Infraestructura/Startup.cs
+++ b/Infraestructura/Startup.cs
@@ -7,7 +7,6 @@ using Infraestructura.Sesiones;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,17 +29,16 @@ namespace Infraestructura
         private void ConfigurarAutenticacion(JwtBearerOptions opciones)
         {
             var token = Environment.GetEnvironmentVariable("TOKEN");
-            var llave = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(token));
 
             opciones.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,
                 ValidateAudience = true,
-                ValidateIssuerSigningKey = true,
                 ValidIssuer = token,
                 ValidAudience = token,
-                IssuerSigningKey = llave,
-                ValidateLifetime = true
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(token)),
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero
             };
         }
 
@@ -58,7 +56,7 @@ namespace Infraestructura
             services.AddSingleton(
                 service =>
                 {
-                    string baseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost:5000";
+                    string baseUrl = Environment.GetEnvironmentVariable("BASE_URL") ?? "https://localhost:5001/";
 
                     return new HttpClient
                     {


### PR DESCRIPTION
Se presenta un problema a la hora de validar la firma del token ya que la opción `ValidateIssuerSigningKey` en el archivo `Startup.cs` estaba activa y finalmente no se validaba correctamente en entornos de desarrollo. 