### PR TITLE
Solventar peticiones duplicadas

### DIFF
--- a/Infraestructura/Cargos/Vistas/RegistrarCargo.razor
+++ b/Infraestructura/Cargos/Vistas/RegistrarCargo.razor
@@ -68,7 +68,7 @@
         <div class="level-right">
             <FormButtons IsLoading="Cargando">
                 <CancelButton To="/cargo">Cancelar</CancelButton>
-                <SubmitButton>Modificar</SubmitButton>
+                <SubmitButton>Registrar</SubmitButton>
             </FormButtons>
         </div>
     </div>

--- a/Infraestructura/Clientes/Vistas/ModificarCliente.razor
+++ b/Infraestructura/Clientes/Vistas/ModificarCliente.razor
@@ -15,7 +15,7 @@
             <nav class="breadcrumb is-small">
                 <ul>
                     <li><a href="/cliente">Cliente</a></li>
-                    <li class="is-active"><a href="#">Registrar</a></li>
+                    <li class="is-active"><a href="#">Modificar</a></li>
                 </ul>
             </nav>
         </div>

--- a/Infraestructura/Clientes/Vistas/RegistrarCliente.razor
+++ b/Infraestructura/Clientes/Vistas/RegistrarCliente.razor
@@ -66,12 +66,6 @@
         <PhoneField id="telefono" @bind-Value="Cliente.Telefono" placeholder="######" />
         <FormFeedback For="() => Cliente.Telefono" Help="Dato de contacto" />
     </FormField>
-  
-    <FormField>
-        <CheckboxField @bind-Value="Cliente.Activo">
-            <span>¿Va a estar activo en el sistema?</span>
-        </CheckboxField>
-    </FormField>
 
     <div class="content">
         <h6 class="subtitle is-6">Al registrar aceptas nuestros <a href="/terminos">Términos y condiciones de privacidad</a></h6>

--- a/Infraestructura/Clientes/Vistas/TarjetaCliente.razor
+++ b/Infraestructura/Clientes/Vistas/TarjetaCliente.razor
@@ -1,63 +1,57 @@
 ﻿@inject HttpClient http
 
-    <div class="card">
-        <div class="card-content">
-            <div class="content">
-                <h6 class="title is-6">@(cliente.Nombre.ToCapitalize())</h6>
+<div class="card">
+    <div class="card-content">
+        <div class="content">
+            <h6 class="title is-6">@(cliente.Nombre.ToCapitalize())</h6>
 
-                <div class="field is-grouped is-grouped-multiline">
-                    <div class="control">
-                        <div class="tags has-addons">
-                            <div class="tag is-dark">RUT</div>
-                            <div class="tag is-light">@cliente.Rut</div>
-                        </div>
+            <div class="field is-grouped is-grouped-multiline">
+                <div class="control">
+                    <div class="tags has-addons">
+                        <div class="tag is-dark">RUT</div>
+                        <div class="tag is-light">@cliente.Rut</div>
                     </div>
+                </div>
 
-                    <div class="content">
-                        <div class="tags">
-                            @if (cliente.Activo)
-                            {
-                                <div class="tag is-success">Activo</div>
-                            }
+                <div class="content">
+                    <div class="tags">
+                        @if (cliente.Activo)
+                        {
+                            <div class="tag is-success">Activo</div>
+                        }
 
-                            else
-                            {
-                                <div class="tag is-warning">Inactivo</div>
-                            }
-                        </div>
-                        </div>
+                        else
+                        {
+                            <div class="tag is-warning">Inactivo</div>
+                        }
                     </div>
-            </div>
-        </div>
-        <div class="card-footer">
-            <a href="/cliente/modificar/@cliente.Id" class="card-footer-item">
-                <span class="icon">
-                    <box-icon name='edit-alt' color='#a69f99'></box-icon>
-                </span>
-            </a>
+                    </div>
+                </div>
         </div>
     </div>
+    <div class="card-footer">
+        <a href="/cliente/modificar/@cliente.Id" class="card-footer-item">
+            <span class="icon">
+                <box-icon name='edit-alt' color='#a69f99'></box-icon>
+            </span>
+        </a>
+    </div>
+</div>
 
 @code {
     [Parameter]
-    public Cliente cliente { get; set; }
+    public Cliente cliente { get; set; } = new Cliente();
 
     [Parameter]
     public EventCallback onDeleted { get; set; }
 
-    bool cargando = false;
-
-    async Task Eliminar()
+    private async Task Eliminar()
     {
-        cargando = true;
-
-        HttpResponseMessage respuesta = await http.DeleteAsync($"/api/cliente/{cliente.Id}");
+        var respuesta = await http.DeleteAsync($"/api/cliente/{cliente.Id}");
 
         if (respuesta.IsSuccessStatusCode && onDeleted.HasDelegate)
         {
             await onDeleted.InvokeAsync(null);
         }
-
-        cargando = false;
     }
 }

--- a/Infraestructura/Compartido/Inicio.razor
+++ b/Infraestructura/Compartido/Inicio.razor
@@ -11,3 +11,5 @@
         <Landing />
     </NotAuthorized>
 </AuthorizeView>
+
+<ToastGroup />

--- a/Infraestructura/Entradas/Vistas/RegistrarEntrada.razor
+++ b/Infraestructura/Entradas/Vistas/RegistrarEntrada.razor
@@ -64,21 +64,21 @@
 </EditForm>
 
 @code {
-        Entrada entrada { get; set; } = new Entrada();
+    Entrada entrada { get; set; } = new Entrada();
 
-        bool cargando = false;
+    bool cargando = false;
 
-        List<DetalleEntrada> detalles = new List<DetalleEntrada>();
+    List<DetalleEntrada> detalles = new List<DetalleEntrada>();
 
-        Producto[] listaProductos = new Producto[0];
+    Producto[] listaProductos = new Producto[0];
 
-        bool deshabilitar
+    bool deshabilitar
     {
-            get
+        get
         {
-                return listaProductos.Length == 0;
-            }
+            return listaProductos.Length == 0;
         }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -104,39 +104,44 @@
         detalles.Remove((DetalleEntrada) detalle);
     }
 
-    async Task Enviar()
+    private async Task Enviar()
     {
         try
         {
-            foreach (var detalle in detalles)
+            if (detalles.Any() && detalles.All(d => d.Producto != 0 && d.Cantidad != 0))
             {
-                if (detalle.Producto == 0 || detalle.Cantidad == 0)
-                {
-                    toaster.ShowWarning("Falta algún valor del detalle");
-                }
-                else
-                {
-                    cargando = true;
-                    var formulario = new FormularioRegistrarEntrada()
-                    {
-                        Entrada = entrada,
-                        Detalles = detalles
-                    };
+                cargando = true;
 
-                    var respuesta = await http.PostAsJsonAsync("/api/entrada", formulario);
+                var formulario = new FormularioRegistrarEntrada()
+                {
+                    Entrada = entrada,
+                    Detalles = detalles
+                };
 
-                    if (respuesta.IsSuccessStatusCode)
-                    {
-                        navegador.NavigateTo("/entrada");
-                    }
-                    cargando = false;
+                var respuesta = await http.PostAsJsonAsync("/api/entrada", formulario);
+
+                if (respuesta.IsSuccessStatusCode)
+                {
+                    navegador.NavigateTo("/entrada");
                 }
+            }
+
+            else
+            {
+                toaster.ShowWarning("Falta algún valor del detalle");
             }
         }
 
         catch
         {
-            throw; // TODO
+#if DEBUG
+            throw;
+#endif
+        }
+
+        finally
+        {
+            cargando = false;
         }
     }
 }

--- a/Infraestructura/Entradas/Vistas/TarjetaEntrada.razor
+++ b/Infraestructura/Entradas/Vistas/TarjetaEntrada.razor
@@ -50,8 +50,6 @@
 
     DetalleEntrada[] detalles { get; set; } = new DetalleEntrada[0];
 
-    bool cargando = false;
-
     #region Modal
     bool mostrarModal = false;
 

--- a/Infraestructura/Notificaciones/Vistas/RegistrarNotificacion.razor
+++ b/Infraestructura/Notificaciones/Vistas/RegistrarNotificacion.razor
@@ -1,28 +1,30 @@
-﻿@using System.Security.Claims
-@using Aplicacion.Notificaciones
+﻿@attribute [Authorize(Roles = "usuarios")]
 
 @inject HttpClient http
 @inject NavigationManager navegador
 @inject AuthenticationStateProvider autentificacion
 @inject IToastService toaster
-@attribute [Authorize(Roles = "usuarios")]
 
 @page "/notificacion/registrar"
 @layout AppLayout
 
-    <div class="level">
-        <div class="level-left">
-            <h3 class="title is-3">Registrar Notificación</h3>
-        </div>
-        <div class="level-right">
-            <nav class="breadcrumb">
-                <ul>
-                    <li><a href="/notificacion">Notificación</a></li>
-                    <li class="is-active"><a href="#">Registrar</a></li>
-                </ul>
-            </nav>
-        </div>
+@using System.Security.Claims
+@using Aplicacion.Notificaciones
+@using Infraestructura.Sesiones
+
+<div class="level">
+    <div class="level-left">
+        <h3 class="title is-3">Registrar Notificación</h3>
     </div>
+    <div class="level-right">
+        <nav class="breadcrumb">
+            <ul>
+                <li><a href="/notificacion">Notificación</a></li>
+                <li class="is-active"><a href="#">Registrar</a></li>
+            </ul>
+        </nav>
+    </div>
+</div>
 
 <hr />
 
@@ -115,55 +117,52 @@
     {
         try
         {
-            foreach (var segmento in segmentos)
+            if (notificacion.FechaFin <= notificacion.FechaInicio)
             {
-                if (notificacion.FechaFin < notificacion.FechaInicio)
-                {
-                    toaster.ShowWarning("La fecha de caducidad no puede ser menor a 1 día despues del inicio");
-                }
+                toaster.ShowWarning("La fecha de caducidad no puede ser menor a 1 día después del inicio");
+            }
 
-                else if (segmento.Cargo == 0)
+            if (segmentos.Any() && segmentos.All(s => s.Cargo != 0))
+            {
+                cargando = true;
+
+                var proveedor = (ProveedorAutenticacion)autentificacion;
+
+                if (await proveedor.GetUserAsync() is Usuario usuario)
                 {
-                    toaster.ShowWarning("Te falta especificar el segmento");
+                    notificacion.Autor = usuario.Id;
+
+                    var formulario = new FormularioRegistrarNotificacion()
+                    {
+                        Notificacion = notificacion,
+                        Segmentos = segmentos
+                    };
+
+                    var respuesta = await http.PostAsJsonAsync("/api/notificacion", formulario);
+
+                    if (respuesta.IsSuccessStatusCode)
+                    {
+                        navegador.NavigateTo("/notificacion");
+                    }
                 }
 
                 else
                 {
-                    cargando = true;
-
-                    var estado = await autentificacion.GetAuthenticationStateAsync();
-                    var serial = estado.User.FindFirst(ClaimTypes.SerialNumber);
-
-                    if (serial is null)
-                    {
-                        // TODO
-                    }
-
-                    else
-                    {
-                        int id = int.Parse(serial.Value);
-                        notificacion.Autor = id;
-
-                        var formulario = new FormularioRegistrarNotificacion()
-                        {
-                            Notificacion = notificacion,
-                            Segmentos = segmentos
-                        };
-
-                        var respuesta = await http.PostAsJsonAsync("/api/notificacion", formulario);
-
-                        if (respuesta.IsSuccessStatusCode)
-                        {
-                            navegador.NavigateTo("/notificacion");
-                        }
-                    }
+                    toaster.ShowError("No estas autenticado en el sistema");
                 }
+            }
+
+            else
+            {
+                toaster.ShowWarning("Completa correctamente los segmentos de la notificación");
             }
         }
 
         catch
         {
-            // TODO
+#if DEBUG
+            throw;
+#endif
         }
 
         finally

--- a/Infraestructura/Pedidos/Vistas/ModificarPedido.razor
+++ b/Infraestructura/Pedidos/Vistas/ModificarPedido.razor
@@ -82,7 +82,7 @@
         <div class="level-right">
             <FormField IsLoading="cargando">
                 <CancelButton To="/pedido">Cancelar</CancelButton>
-                <SubmitButton>Registrar</SubmitButton>
+                <SubmitButton>Modificar</SubmitButton>
             </FormField>
         </div>
     </div>

--- a/Infraestructura/Pedidos/Vistas/RegistrarPedido.razor
+++ b/Infraestructura/Pedidos/Vistas/RegistrarPedido.razor
@@ -1,29 +1,31 @@
-﻿@using System.Security.Claims
-@using static System.Globalization.CultureInfo
-@using Aplicacion.Pedidos.Formularios
+﻿@attribute [Authorize(Roles = "solicitar")]
 
 @inject HttpClient http
 @inject NavigationManager navegador
 @inject AuthenticationStateProvider autentificacion
 @inject IToastService toaster
-@attribute [Authorize(Roles = "solicitar")]
 
 @page "/pedido/registrar"
 @layout AppLayout
 
-    <div class="level">
-        <div class="level-left">
-            <h3 class="title is-3">Solicitar Pedido</h3>
-        </div>
-        <div class="level-right">
-            <nav class="breadcrumb is-small">
-                <ul>
-                    <li><a href="/pedido">Solicitar</a></li>
-                    <li class="is-active"><a href="#">Registrar</a></li>
-                </ul>
-            </nav>
-        </div>
+@using System.Security.Claims
+@using Aplicacion.Pedidos.Formularios
+@using Infraestructura.Sesiones
+
+<div class="level">
+    <div class="level-left">
+        <h3 class="title is-3">Solicitar Pedido</h3>
     </div>
+    <div class="level-right">
+        <nav class="breadcrumb is-small">
+            <ul>
+                <li><a href="/pedido">Solicitar</a></li>
+                <li class="is-active"><a href="#">Registrar</a></li>
+            </ul>
+        </nav>
+    </div>
+</div>
+
 <hr />
 
 <EditForm Model="pedido" OnValidSubmit="Enviar">
@@ -80,10 +82,15 @@
 </EditForm>
 
 @code {
-    Array estados = Enum.GetValues(typeof(Estado));
-    Cliente[] cliente { get; set; } = new Cliente[0];
-    Usuario[] usuarios { get; set; } = new Usuario[0];
-    Producto[] listaProductos { get; set; }
+    private Array estados = Enum.GetValues(typeof(Estado));
+    private Cliente[] cliente { get; set; } = new Cliente[0];
+    private Usuario[] usuarios { get; set; } = new Usuario[0];
+    private Producto[] listaProductos { get; set; }
+
+    private List<DetallePedido> detalles = new List<DetallePedido>();
+
+    private Pedido pedido { get; set; } = new Pedido();
+    private bool cargando = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -111,60 +118,56 @@
         detalles.Remove((DetallePedido)detalle);
     }
 
-    List<DetallePedido> detalles = new List<DetallePedido>();
-
-    Pedido pedido { get; set; } = new Pedido();
-    bool cargando = false;
-
-    async Task Enviar()
+    private async Task Enviar()
     {
         cargando = true;
 
         try
         {
-            foreach (var detalle in detalles)
+            if (detalles.Any() && detalles.All(d => d.Producto != 0 && d.Cantidad != 0))
             {
-                if (detalle.Producto == 0 || detalle.Cantidad == 0)
+                cargando = true;
+
+                var proveedor = (ProveedorAutenticacion)autentificacion;
+
+                if (await proveedor.GetUserAsync() is Usuario usuario)
                 {
-                    toaster.ShowWarning("Falta algún valor del detalle, favor verificar");
-                }
-                else
-                {
-                    cargando = true;
-                    var estado = await autentificacion.GetAuthenticationStateAsync();
-                    var serial = estado.User.FindFirst(ClaimTypes.SerialNumber);
+                    pedido.Asesor = usuario.Id;
+
                     var formulario = new FormularioRegistrarPedido()
                     {
                         Pedido = pedido,
                         Detalles = detalles
                     };
-                    if (serial is null)
+
+                    var respuesta = await http.PostAsJsonAsync("/api/pedido", formulario);
+
+                    if (respuesta.IsSuccessStatusCode)
                     {
-                        // TODO
+                        navegador.NavigateTo("/pedido");
+                        toaster.ShowSuccess("Registro realizado de forma exitosa");
                     }
 
-                    else
-                    {
-                        int id = int.Parse(serial.Value);
-                        pedido.Asesor = id;
-
-                        var respuesta = await http.PostAsJsonAsync("/api/pedido", formulario);
-
-                        if (respuesta.IsSuccessStatusCode)
-                        {
-                            navegador.NavigateTo("/pedido");
-                            toaster.ShowSuccess("Registro realizado de forma exitosa");
-                        }
-                        cargando = false;
-                    }
+                    cargando = false;
                 }
 
+                else
+                {
+                    toaster.ShowError("No estas autenticado en el sistema");
+                }
+            }
+
+            else
+            {
+                toaster.ShowWarning("Falta algún valor del detalle");
             }
         }
 
         catch
         {
-            // TODO
+#if DEBUG
+            throw;
+#endif
         }
 
         finally

--- a/Infraestructura/Productos/Vistas/ListarCategoria.razor
+++ b/Infraestructura/Productos/Vistas/ListarCategoria.razor
@@ -37,7 +37,7 @@ else
         @foreach (Categoria categoria in categoria)
         {
             <div class="column is-full-mobile is-half-tablet is-one-third-desktop">
-                <TarjetaCategoria categoria="categoria" OnCategoriaEliminada="ObtenerListado"></TarjetaCategoria>
+                <TarjetaCategoria categoria="categoria"></TarjetaCategoria>
             </div>
         }
     </div>
@@ -45,12 +45,13 @@ else
 
 @code {
     Categoria[] categoria { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await ObtenerListado();
     }
 
-    async Task ObtenerListado()
+    private async Task ObtenerListado()
     {
         categoria = await http.GetFromJsonAsync<Categoria[]>("/api/categoria");
     }

--- a/Infraestructura/Productos/Vistas/TarjetaProducto.razor
+++ b/Infraestructura/Productos/Vistas/TarjetaProducto.razor
@@ -33,9 +33,7 @@
     [Parameter]
     public EventCallback<Producto> OnProductoEliminado { get; set; }
 
-    Categoria categoria { get; set; }
-
-    bool cargando = false;
+    private Categoria categoria { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/Infraestructura/Salidas/Vistas/RegistrarSalida.razor
+++ b/Infraestructura/Salidas/Vistas/RegistrarSalida.razor
@@ -7,28 +7,21 @@
 @page "/salida/registrar"
 @attribute [Authorize(Roles = "logistica")] 
 
-    <div class="level">
-        <div class="level-left">
-            <h3 class="title is-3">Registrar Salida</h3>
-        </div>
-        <div class="level-right">
-            <nav class="breadcrumb is-small">
-                <ul>
-                    <li><a href="/salida">Egresos</a></li>
-                    <li class="is-active"><a href="#">Registrar</a></li>
-                </ul>
-            </nav>
-        </div>
+<div class="level">
+    <div class="level-left">
+        <h3 class="title is-3">Registrar Salida</h3>
     </div>
+    <div class="level-right">
+        <nav class="breadcrumb is-small">
+            <ul>
+                <li><a href="/salida">Egresos</a></li>
+                <li class="is-active"><a href="#">Registrar</a></li>
+            </ul>
+        </nav>
+    </div>
+</div>
 
-    <hr />
-
-    @if (mensaje is string)
-    {
-        <blockquote class="is-warn">
-            <p>@mensaje</p>
-        </blockquote>
-    }
+<hr />
 
 <EditForm Model="salida" OnValidSubmit="Enviar">
     <DataAnnotationsValidator></DataAnnotationsValidator>
@@ -68,14 +61,12 @@
 </EditForm>
 
 @code {
-    bool cargando = false;
+    private bool cargando = false;
 
-    string mensaje;
+    private Salida salida { get; set; } = new Salida();
 
-    Salida salida { get; set; } = new Salida();
-
-    List<DetalleSalida> detalles = new List<DetalleSalida>();
-    Producto[] listaProductos { get; set; }
+    private List<DetalleSalida> detalles = new List<DetalleSalida>();
+    private Producto[] listaProductos;
 
     protected override async Task OnInitializedAsync()
     {
@@ -100,39 +91,42 @@
         detalles.Remove((DetalleSalida) detalle);
     }
 
-    async Task Enviar()
+    private async Task Enviar()
     {
         try
         {
-            foreach (var detalle in detalles)
+            if (detalles.Any() && detalles.All(d => d.Producto != 0 && d.Cantidad != 0))
             {
-                if (detalle.Producto == 0 || detalle.Cantidad == 0)
+                cargando = true;
+                var formulario = new FormularioRegistrarSalida()
                 {
-                    toaster.ShowWarning("Falta algún valor del detalle");
-                }
+                    Salida = salida,
+                    Detalles = detalles
+                };
 
-                else
+                var respuesta = await http.PostAsJsonAsync("/api/salida", formulario);
+
+                if (respuesta.IsSuccessStatusCode)
                 {
-                    cargando = true;
-                    var formulario = new FormularioRegistrarSalida()
-                    {
-                        Salida = salida,
-                        Detalles = detalles
-                    };
-
-                    var respuesta = await http.PostAsJsonAsync("/api/salida", formulario);
-
-                    if (respuesta.IsSuccessStatusCode)
-                    {
-                        navegador.NavigateTo("/salida");
-                    }
-                    cargando = false;
+                    navegador.NavigateTo("/salida");
                 }
+            }
+
+            else
+            {
+                toaster.ShowWarning("Falta algún valor del detalle");
             }
         }
         catch
         {
-            mensaje = "Hubo un error al insertar";
+#if DEBUG
+            throw;
+#endif
+        }
+
+        finally
+        {
+            cargando = false;
         }
     }
 }

--- a/Infraestructura/Sesiones/Vistas/Perfil/CambiarClave.razor
+++ b/Infraestructura/Sesiones/Vistas/Perfil/CambiarClave.razor
@@ -7,6 +7,8 @@
 <EditForm Model="Formulario" OnValidSubmit="Enviar">
     <DataAnnotationsValidator />
 
+    <p>Al cambiar tu contraseña, tu sesión será cerrada para que vuelvas a ingresar tus credenciales.</p>
+
     <FormField Label="Contraseña actual">
         <PasswordField id="claveActual" @bind-Value="Formulario.ClaveAnterior" HiddenOnly />
         <FormFeedback For="() => Formulario.ClaveAnterior" />
@@ -48,19 +50,35 @@
 
         try
         {
-            var respuesta = await http.PutAsJsonAsync("/api/sesion/cambiar_clave", Formulario);
-
-            if (respuesta.IsSuccessStatusCode)
+            if (Formulario.ConfirmacionClave == Formulario.NuevaClave)
             {
-                var proveedor = (ProveedorAutenticacion) autentificacion;
-                await proveedor.SignOut();
+                var respuesta = await http.PutAsJsonAsync("/api/sesion/cambiar_clave", Formulario);
+
+                if (respuesta.IsSuccessStatusCode)
+                {
+                    var proveedor = (ProveedorAutenticacion)autentificacion;
+                    await proveedor.SignOut();
+                }
+
+                else
+                {
+                    toaster.ShowWarning("Revisa tus credenciales");
+                }
+            }
+
+            else
+            {
+                toaster.ShowWarning("Las contraseñas no coinciden");
             }
         }
 
         catch
         {
             toaster.ShowError("Hubo un error en el proceso, recarga la página e intenta nuevamente");
+
+#if DEBUG
             throw;
+#endif
         }
 
         finally

--- a/Infraestructura/Sesiones/Vistas/ReestablecerClave.razor
+++ b/Infraestructura/Sesiones/Vistas/ReestablecerClave.razor
@@ -38,7 +38,7 @@
             <div class="level">
                 <div class="level-left"><span></span></div>
                 <div class="level-right">
-                    <FormButtons>
+                    <FormButtons IsLoading="Cargando">
                         <CancelButton To="/">Cancelar</CancelButton>
                         <SubmitButton>Reestablecer clave</SubmitButton>
                     </FormButtons>
@@ -74,9 +74,9 @@
         catch
         {
             toaster.ShowError("Hubo un error desconocido, intenta más tarde");
-            #if DEBUG
+#if DEBUG
             throw;
-            #endif
+#endif
         }
 
         finally


### PR DESCRIPTION
Al realizar el registro de un nuevo pedido, salida, entrada o notificación, se está duplicando puesto que se estaba realizando una validación de forma errada utilizando un `foreach` lo cual enviaba la petición el número de veces que hubiera segmentos o productos que adjuntar. Se muestra un ejemplo a continuación:

https://github.com/kuic-sena/servidor/blob/b585bf067ad7699064ddc3a5f5acdf9f6e87ab95/Infraestructura/Notificaciones/Vistas/RegistrarNotificacion.razor#L118-L161
